### PR TITLE
Add pull subscription event methods, and move over from subscribe

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.13']
         os: [ubuntu-latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sailhouse"
-version = "0.1.0"
+version = "0.1.1"
 description = "Python SDK for Sailhouse - Event Streaming Platform"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Since the platform now supports [pulling and locking events](https://docs.sailhouse.dev/api-reference/events/pull), we should use these methods in the event-processing logic.

We still want `get_events` for bulk actions which may not be lockable.